### PR TITLE
fix: change EGID scale 10 to x10

### DIFF
--- a/django/core/models.py
+++ b/django/core/models.py
@@ -44,7 +44,7 @@ class Language(Model):
         ('8a', 'Moribund (8a)'),
         ('8b', 'Nearly Extinct (8b)'),
         ('9', 'Dormant (9)'),
-        ('10', 'Extinct (10)'),
+        ('x10', 'Extinct (10)'),
     )
 
     code = models.CharField(


### PR DESCRIPTION
마이너한 수정입니다. Ethnologue Global Dataset (SIL International) 의 데이터 형식([링크](http://www.ethnologue.com/sites/default/files/Ethnologue-19-Global%20Dataset%20Doc.pdf))에 일관되게 하기 위해 EGIDS 스케일 Extinct (10)의 코드를 `10` 에서 `x10` 으로 수정하였습니다. (Alphabetical sorting 목적)